### PR TITLE
Some improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,48 @@
 FROM alpine:3.3
 MAINTAINER Hardware <contact@meshup.net>
 
-ENV GID=991 UID=991 VERSION=2.93 DBHOST=mariadb DBUSER=postfix DBNAME=postfix
+ARG VERSION=2.93
+
+ARG GPG_Goodwin="2D83 3163 D69B B8F6 BFEF  179D 4ECC 3566 EB7E B945"
+
+ENV GID=991 \
+    UID=991 \
+    DBHOST=mariadb \
+    DBUSER=postfix \
+    DBNAME=postfix
 
 RUN echo "@commuedge http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+ && echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+ && BUILD_DEPS=" \
+    ca-certificates \
+    gnupg" \
  && apk -U add \
+    ${BUILD_DEPS} \
     nginx \
-    php-fpm \
-    php-imap \
-    php-mysql \
-    php-mysqli \
+    php7-fpm@testing \
+    php7-imap@testing \
+    php7-mysqli@testing \
+    php7-session@testing \
     dovecot \
     supervisor \
     tini@commuedge \
-  && rm -f /var/cache/apk/*
-
-RUN wget -q http://downloads.sourceforge.net/project/postfixadmin/postfixadmin/postfixadmin-$VERSION/postfixadmin-$VERSION.tar.gz -P /tmp \
- && mkdir /postfixadmin && tar -xzf /tmp/postfixadmin-$VERSION.tar.gz -C /postfixadmin && mv /postfixadmin/postfixadmin-$VERSION/* /postfixadmin \
- && rm -rf /tmp/* /postfixadmin/postfixadmin-$VERSION*
+ && cd /tmp \
+ && PFA_TARBALL="postfixadmin-${VERSION}.tar.gz" \
+ && wget -q https://downloads.sourceforge.net/project/postfixadmin/postfixadmin/postfixadmin-${VERSION}/${PFA_TARBALL} \
+ && echo "Verifying ${PFA_TARBALL} using GPG..." \
+ && wget -q https://downloads.sourceforge.net/project/postfixadmin/postfixadmin/postfixadmin-${VERSION}/${PFA_TARBALL}.asc \
+ && gpg --keyserver keys.gnupg.net --recv-keys 0xEB7EB945 \
+ && FINGERPRINT="$(LANG=C gpg --verify ${PFA_TARBALL}.asc ${PFA_TARBALL} 2>&1 \
+  | sed -n "s#Primary key fingerprint: \(.*\)#\1#p")" \
+ && if [ -z "${FINGERPRINT}" ]; then echo "Warning! Invalid GPG signature!" && exit 1; fi \
+ && if [ "${FINGERPRINT}" != "${GPG_Goodwin}" ]; then echo "Warning! Wrong GPG fingerprint!" && exit 1; fi \
+ && echo "All seems good, now unpacking ${PFA_TARBALL}..." \
+ && mkdir /postfixadmin && tar xzf ${PFA_TARBALL} -C /postfixadmin && mv /postfixadmin/postfixadmin-$VERSION/* /postfixadmin \
+ && apk del ${BUILD_DEPS} \
+ && rm -rf /var/cache/apk/* /tmp/* /postfixadmin/postfixadmin-$VERSION*
 
 COPY nginx.conf /etc/nginx/nginx.conf
-COPY php-fpm.conf /etc/php/php-fpm.conf
+COPY php-fpm.conf /etc/php7/php-fpm.conf
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 COPY setup /usr/local/bin/setup
 COPY startup /usr/local/bin/startup
@@ -29,4 +51,4 @@ RUN chmod +x /usr/local/bin/startup /usr/local/bin/setup
 
 EXPOSE 80
 
-CMD ["tini","--","startup"]
+CMD ["/sbin/tini","--","startup"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ https://github.com/hardware/mailserver/wiki/Reverse-proxy-configuration
 
 https://github.com/hardware/mailserver/wiki/Postfixadmin-initial-configuration
 
+### Built-time variables
+
+- **VERSION** : version of postfixadmin
+- **GPG_Goodwin** : fingerprint of signing key
+
 ### Environment variables
 
 - **GID** = postfixadmin user id (*optional*, default: 991)

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:php-fpm]
-command=php-fpm
+command=php-fpm7
 
 [program:nginx]
 command=nginx


### PR DESCRIPTION
- PHP5 -> PHP7.
- Tarball authenticity checking (GPG).
- Resolved tini warnings (use /sbin/tini).
- Use HTTPS to download postfixadmin.
