### PR TITLE
[Config] Dynamic SMTPHOST and DOMAIN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV GID=991 \
     UID=991 \
     DBHOST=mariadb \
     DBUSER=postfix \
-    DBNAME=postfix
+    DBNAME=postfix \
+    SMTPHOST=mailserver
 
 RUN echo "@commuedge https://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
  && BUILD_DEPS=" \

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ https://github.com/hardware/mailserver/wiki/Postfixadmin-initial-configuration
 - **DBUSER** = MYSQL database username (*optional*, default: postfix)
 - **DBNAME** = MYSQL database name (*optional*, default: postfix)
 - **DBPASS** = MYSQL database (**required**)
+- **SMTPHOST** = SMTP host (*optional*, default: mailserver)
+- **DOMAIN** = Mail domain (*optional*, default: domainname of container)
 
 ### Docker-compose
 

--- a/startup
+++ b/startup
@@ -2,7 +2,8 @@
 
 # ENV
 export DOMAIN
-DOMAIN="$(hostname --domain)"
+
+DOMAIN=${DOMAIN:-$(hostname --domain)}
 
 if [ -z "$DBPASS" ]; then
   echo "Mariadb database password must be set !"
@@ -27,7 +28,7 @@ cat > /postfixadmin/config.local.php <<EOF
 \$CONF['encrypt'] = 'dovecot:SHA512-CRYPT';
 \$CONF['dovecotpw'] = "/usr/bin/doveadm pw";
 
-\$CONF['smtp_server'] = 'mailserver';
+\$CONF['smtp_server'] = '${SMTPHOST}';
 \$CONF['domain_path'] = 'YES';
 \$CONF['domain_in_mailbox'] = 'NO';
 \$CONF['fetchmail'] = 'NO';


### PR DESCRIPTION
Allow dynamic configuration of :
- SMTPHOST: Hostname of smtpserver for config.local.php
- DOMAIN: Domain for config.local.php

When i use docker 1.12+ with swarm when i create a service, i cannot chose the hostname, domainname.
Passing this data through env vars is one solution.
